### PR TITLE
removing 'engines' from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "engines": {
-    "node": "~0.10.22"
-  },
   "dependencies": {
     "caller": "^1.0.0"
-},
+  },
   "devDependencies": {
     "tape": "^2.4.2",
     "istanbul": "~0.2.3",


### PR DESCRIPTION
This will fix the error I see in my app
error callermodule@1.0.3: The engine "node" is incompatible with this module. Expected version "~0.10.22".
